### PR TITLE
Added basic proc counter and percentage display for skill gains

### DIFF
--- a/LootNanny.py
+++ b/LootNanny.py
@@ -354,7 +354,7 @@ class LootNanny(QWidget):
         self.total_skills_text = QLineEdit(enabled=False)
         form_inputs.addRow("Total Skill Gain:", self.total_skills_text)
 
-        table = SkillTableView({"Skill": [], "Value": []}, 40, 2)
+        table = SkillTableView({"Skill": [], "Value": [], "Proc": [], "Proc %": []}, 40, 4)
 
         # eulogger.skill_table = table
         layout.addLayout(form_inputs)

--- a/modules/combat.py
+++ b/modules/combat.py
@@ -245,9 +245,7 @@ class HuntingTrip(object):
         
         # Get total procs during hunt
         tp = sum(i[1] for i in sorted(self.skillprocs.items(), key=lambda t: t[1], reverse=True))
-        print("DEBUG - TP: " + str(tp))
         for k, v in sorted(self.skillprocs.items(), key=lambda t: t[1], reverse=True):
-            print("DEBUG: K V - " + str(k) + " --- " + str(v))
             d["Procs"].append(v)
             d["Proc %"].append("{:.00%}".format(v/tp)) if tp != 0 else d["Proc %"].append("{:.00%}".format(0))
         return d
@@ -345,7 +343,6 @@ class CombatModule(BaseModule):
                     self.active_run.add_combat_chat_row(chat_instance)
                     self.should_redraw_runs = True
                 elif isinstance(chat_instance, LootInstance):
-                    print(chat_instance)
                     self.active_run.add_loot_instance_chat_row(chat_instance)
                     self.should_redraw_runs = True
                 elif isinstance(chat_instance, EnhancerBreakages):

--- a/modules/combat.py
+++ b/modules/combat.py
@@ -70,6 +70,7 @@ class HuntingTrip(object):
 
         # Skillgains
         self.skillgains = defaultdict(int)
+        self.skillprocs = defaultdict(int)
 
         # Combat Stats
         self.total_attacks = 0
@@ -96,6 +97,7 @@ class HuntingTrip(object):
             },
             "loot": {k: {"c": v["c"], "v": str(v["v"])} for k, v in self.looted_items.items()},
             "skills": dict(self.skillgains),
+            "skillprocs": dict(self.skillprocs),
             "enhancers": dict(self.enhancer_breaks),
             "combat": {
                 "attacks": self.total_attacks,
@@ -159,6 +161,7 @@ class HuntingTrip(object):
 
     def add_skillgain_row(self, row: SkillRow):
         self.skillgains[row.skill] += row.amount
+        self.skillprocs[row.skill] += 1
 
     def add_enhancer_break_row(self, row: EnhancerBreakages):
         self.enhancer_breaks[row.type] += 1
@@ -235,10 +238,18 @@ class HuntingTrip(object):
         return Decimal(0.0)
 
     def get_skill_table_data(self):
-        d = {"Skill": [], "Value": []}
+        d = {"Skill": [], "Value": [], "Procs":[], "Proc %":[]}
         for k, v in sorted(self.skillgains.items(), key=lambda t: t[1], reverse=True):
             d["Skill"].append(k)
             d["Value"].append("%.4f" % v)
+        
+        # Get total procs during hunt
+        tp = sum(i[1] for i in sorted(self.skillprocs.items(), key=lambda t: t[1], reverse=True))
+        print("DEBUG - TP: " + str(tp))
+        for k, v in sorted(self.skillprocs.items(), key=lambda t: t[1], reverse=True):
+            print("DEBUG: K V - " + str(k) + " --- " + str(v))
+            d["Procs"].append(v)
+            d["Proc %"].append("{:.00%}".format(v/tp)) if tp != 0 else d["Proc %"].append("{:.00%}".format(0))
         return d
 
     def get_total_skill_gain(self):

--- a/utils/tables.py
+++ b/utils/tables.py
@@ -18,9 +18,10 @@ class BaseTableView(QTableWidget):
         horHeaders = []
         for n, key in enumerate(self.COLUMNS):
             horHeaders.append(key)
-            for m, item in enumerate(data[key]):
-                newitem = QTableWidgetItem(str(item))
-                self.setItem(m, n, newitem)
+            if key in data:
+                for m, item in enumerate(data[key]):
+                    newitem = QTableWidgetItem(str(item))
+                    self.setItem(m, n, newitem)
         self.setHorizontalHeaderLabels(horHeaders)
 
 
@@ -61,13 +62,15 @@ class LootTableView(BaseTableView):
 
 
 class SkillTableView(BaseTableView):
-    COLUMNS = ("Skill", "Value")
+    COLUMNS = ("Skill", "Value", "Procs", "Proc %")
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         header = self.horizontalHeader()
         header.setSectionResizeMode(0, QHeaderView.Stretch)
         header.setSectionResizeMode(1, QHeaderView.Stretch)
+        header.setSectionResizeMode(2, QHeaderView.Stretch)
+        header.setSectionResizeMode(3, QHeaderView.Stretch)
 
 
 class EnhancerTableView(BaseTableView):


### PR DESCRIPTION
So this was mainly to add a new feature for counting the number of times a skill increase procs, and then collecting percentages. Mainly I was using it to try and gather data on activity / skill increase chance to determine if it was really random or not, and I thought it might be an interesting feature for others to gather data by.

Granted, there may need to be more metrics added for it to be actually useful in multi-loadout hunting.

I also added the procs as a separately tracked item, `skillprocs`. I didn't want to expand the existing tuples in the `skillgains` list to avoid unintended side-effects on existing logs. 

![lootnanny_pr_skill_proc](https://user-images.githubusercontent.com/97069102/147998162-ad97cd47-3d9d-45e8-9407-ccda24c8f4b8.png)
