### PR TITLE
PR for Issue #19 - Add new energy amplifier and carbine entries to attachments and weapons data

### DIFF
--- a/data/raw/attachments.json
+++ b/data/raw/attachments.json
@@ -1046,6 +1046,16 @@
     "decay": "0.0002",
     "type": "Energy Amp"
   },
+  "RDI Energy Amplifier Gamma": {
+    "ammo": 1100,
+    "decay": "0.0002",
+    "type": "Energy Amp"
+  },
+  "RDI Energy Amplifier Gamma (L)": {
+    "ammo": 1000,
+    "decay": "0.0002",
+    "type": "Energy Amp"
+  },
   "Rage 10 (L)": {
     "ammo": 165,
     "decay": "0.00467",

--- a/data/raw/weapons.json
+++ b/data/raw/weapons.json
@@ -10686,6 +10686,16 @@
     "decay": "0.0",
     "type": "Melee"
   },
+  "Omegaton C-120, BGH": {
+    "ammo": 2220,
+    "decay": "0.2500",
+    "type": "Carbine"
+  },
+  "Omegaton C-120, BGH (L)": {
+    "ammo": 2220,
+    "decay": "0.2500",
+    "type": "Carbine"
+  },
   "Omegaton Flashfire": {
     "ammo": 0,
     "decay": "0.20502",


### PR DESCRIPTION
PR for Issue #19 : Added the new C-120 and C-80 BGH weapons to the loadout selection, along with the new L and UL RDI Energy Amplifier Gamma.