### PR TITLE
Fixed a typo in the Mayhem MF-Amplifier name.

### DIFF
--- a/data/raw/attachments.json
+++ b/data/raw/attachments.json
@@ -666,7 +666,22 @@
     "decay": "0.0",
     "type": "Melee Amp"
   },
-  "Mayhem MF-Amplfier Alpha (L)": {
+  "Mayhem MF-Amplifier Alpha (L)": {
+    "ammo": 898,
+    "decay": "0.00019",
+    "type": "MF Amp"
+  },
+  "Mayhem MF-Amplifier Beta (L)": {
+    "ammo": 898,
+    "decay": "0.00019",
+    "type": "MF Amp"
+  },
+  "Mayhem MF-Amplifier Gamma (L)": {
+    "ammo": 898,
+    "decay": "0.00019",
+    "type": "MF Amp"
+  },
+  "Mayhem MF-Amplifier Delta (L)": {
     "ammo": 898,
     "decay": "0.00019",
     "type": "MF Amp"


### PR DESCRIPTION
PR for Issue #15 
Fixed a typo in the Mayhem MF-Amplifier name.
Added the missing Mayhem MF-Amplifier Beta (L), Mayhem MF-Amplifier Gamma (L), and Mayhem MF-Amplifier Delta (L) to the loadout selection.